### PR TITLE
Update es2015andjsx

### DIFF
--- a/doc/basics/es2015andjsx.md
+++ b/doc/basics/es2015andjsx.md
@@ -24,7 +24,7 @@ code will throw lots of `React is not defined` errors.
 
 You can specify this pragma it in each of your
 files with a `@jsx` pragma comment. You will need to put this comment
-at the top of every file that imports `element`.
+at the top of every file that imports `createElement`.
 
 ```js
 /** @jsx createElement */


### PR DESCRIPTION
Thinking the reference to `element` should be `createElement` here. I could be wrong, but figured it'd be easiest to make the change, propose it, and let you see that :)

Also, should the reference in .bablerc also have `createElement` instead of just `element`? There seems to be an inconsistency between the two, so not sure if either is wrong.

Pls reject if I've misread this.